### PR TITLE
feat: LoginScreen UI 구현

### DIFF
--- a/core/navigation/src/main/java/com/example/navigation/MainRoute.kt
+++ b/core/navigation/src/main/java/com/example/navigation/MainRoute.kt
@@ -6,22 +6,28 @@ import kotlinx.serialization.Serializable
 sealed class ScreenRouter(
     val iconId: Int,
     val title: String,
+    val route: String,
 )
 
 @Serializable
 data object HomeScreenRoute : ScreenRouter(
     R.drawable.baseline_home_filled_24,
     "홈",
+    "com.example.navigation.HomeScreenRoute",
 )
 
 @Serializable
 data object MapScreenRoute : ScreenRouter(
     R.drawable.baseline_map_24,
     "지도",
+    "com.example.navigation.MapScreenRoute",
 )
 
 @Serializable
 data object MyPageScreenRoute : ScreenRouter(
     R.drawable.baseline_account_circle_24,
     "마이 페이지",
+    "com.example.navigation.MyPageScreenRoute",
 )
+
+val bottomBarScreens = listOf(HomeScreenRoute, MapScreenRoute, MyPageScreenRoute)

--- a/feature/login/src/main/java/com/example/login/presentation/LoginScreen.kt
+++ b/feature/login/src/main/java/com/example/login/presentation/LoginScreen.kt
@@ -1,40 +1,108 @@
 package com.example.login.presentation
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun LoginScreen(
     onSignUpButtonClick: () -> Unit,
 ) {
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-    ) { innerPadding ->
-        Column(
+    var idText by remember { mutableStateOf("") }
+    var pwText by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "Cow Group",
+            modifier = Modifier.padding(top = 120.dp),
+            style = MaterialTheme.typography.displayLarge,
+            fontStyle = FontStyle.Italic,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(64.dp))
+
+        TextField(
+            value = idText,
             modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .fillMaxWidth()
+                .padding(8.dp),
+            onValueChange = { idText = it },
+            label = { Text(text = "이메일") },
+            placeholder = { Text(text = "이메일을 입력하세요.") },
+        )
+
+        TextField(
+            value = pwText,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            onValueChange = { pwText = it },
+            label = { Text(text = "비밀번호") },
+            placeholder = { Text(text = "비밀번호를 입력하세요.") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            visualTransformation = PasswordVisualTransformation(),
+        )
+
+        Button(
+            onClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 16.dp),
+            enabled = idText.isNotEmpty() && pwText.isNotEmpty(),
         ) {
-            Text(text = "LoginScreen", style = MaterialTheme.typography.displayLarge)
-            Button(onClick = {}) {
-                Text(text = "로그인 버튼")
-            }
-            Button(onClick = onSignUpButtonClick) {
-                Text(text = "회원 가입 버튼")
-            }
-            Button(onClick = {}) {
-                Text(text = "구글 로그인 버튼")
-            }
+            Text(text = "로그인")
+        }
+
+        Text(
+            text = "회원가입",
+            modifier = Modifier.clickable { onSignUpButtonClick() },
+            color = Color.Gray,
+            textDecoration = TextDecoration.Underline,
+        )
+
+        Divider(color = Color.Gray, thickness = 1.dp)
+
+        Text(text = "SNS 로그인")
+
+        Button(
+            onClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+        ) {
+            Text(text = "구글 로그인 버튼")
         }
     }
 }

--- a/feature/login/src/main/java/com/example/login/presentation/LoginScreen.kt
+++ b/feature/login/src/main/java/com/example/login/presentation/LoginScreen.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Divider
 import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -92,7 +92,7 @@ fun LoginScreen(
             textDecoration = TextDecoration.Underline,
         )
 
-        Divider(color = Color.Gray, thickness = 1.dp)
+        HorizontalDivider(color = Color.Gray, thickness = 1.dp)
 
         Text(text = "SNS 로그인")
 

--- a/feature/main/src/main/java/com/example/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/example/main/component/MainBottomBar.kt
@@ -9,23 +9,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.example.navigation.HomeScreenRoute
-import com.example.navigation.MapScreenRoute
-import com.example.navigation.MyPageScreenRoute
+import com.example.navigation.bottomBarScreens
 
 @Composable
 fun MainBottomBar(navController: NavController) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination
 
-    val navItems = listOf(
-        HomeScreenRoute,
-        MapScreenRoute,
-        MyPageScreenRoute,
-    )
-
     NavigationBar {
-        navItems.forEach { navItem ->
+        bottomBarScreens.forEach { navItem ->
             NavigationBarItem(
                 icon = {
                     Icon(

--- a/feature/main/src/main/java/com/example/main/presentation/MainScreen.kt
+++ b/feature/main/src/main/java/com/example/main/presentation/MainScreen.kt
@@ -5,16 +5,22 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.main.component.MainBottomBar
 import com.example.main.component.MainNavHost
+import com.example.navigation.bottomBarScreens
 
 @Composable
 fun MainScreen() {
     val navController = rememberNavController()
+
     Scaffold(
         bottomBar = {
-            MainBottomBar(navController)
+            val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+            if (bottomBarScreens.any { it.route == currentRoute }) {
+                MainBottomBar(navController)
+            }
         },
     ) { innerPadding ->
         MainNavHost(navController, modifier = Modifier.padding(innerPadding))


### PR DESCRIPTION
👩‍🌾 진행한 작업

✅ 바텀 네비게이션 바에 설정된 화면이 아닌 경우 바텀 네비게이션 바 숨기기
✅ LoginScreen UI 구현

📷 작업 결과(사진)
<img src=https://github.com/user-attachments/assets/c137ec84-25ef-4862-ba21-d1ba0a158fcf width =250>

🗣️ 공유할 내용
- 바텀 네비게이션 바 숨길때 끊겨보이는 현상이 있어 Animation 처리가 필요해 보입니다.

closed #11 