### PR TITLE
feat:  DetailEventScreen UI 수정

### DIFF
--- a/core/data/src/main/java/com/example/data/repository/EventRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/EventRepository.kt
@@ -17,7 +17,7 @@ interface EventRepository {
 
     suspend fun updateBookmark(eventId: Int, isBookmarked: Boolean)
 
-    suspend fun createMeeting(createMeeting: CreateMeeting)
+    suspend fun createMeeting(createMeeting: CreateMeeting): Int
 
     suspend fun getEventDetail(eventId: Int): DetailEvent
 

--- a/core/data/src/main/java/com/example/data/repository/EventRepositoryImpl.kt
+++ b/core/data/src/main/java/com/example/data/repository/EventRepositoryImpl.kt
@@ -148,7 +148,7 @@ internal class EventRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createMeeting(createMeeting: CreateMeeting) {
+    override suspend fun createMeeting(createMeeting: CreateMeeting): Int {
         try {
             val filePart = createMeeting.file?.let { file ->
                 val fileRequestBody = file.asRequestBody("image/*".toMediaTypeOrNull())
@@ -159,13 +159,15 @@ internal class EventRepositoryImpl @Inject constructor(
             val capacityPart = createMeeting.capacity.toString().toRequestBody("text/plain".toMediaTypeOrNull())
             val contentPart = createMeeting.content.toRequestBody("text/plain".toMediaTypeOrNull())
 
-            api.createMeeting(
+            val response = api.createMeeting(
                 file = filePart,
                 name = namePart,
                 category = categoryPart,
                 capacity = capacityPart,
                 content = contentPart
             )
+            val eventId = response.data
+            return eventId
         } catch (e: HttpException) {
             throw e
         } catch (e: Exception) {

--- a/core/designsystem/src/main/java/com/example/designsystem/component/CowGroupPhotoPicker.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/CowGroupPhotoPicker.kt
@@ -49,7 +49,7 @@ fun CowGroupPhotoPicker(
     modifier: Modifier = Modifier,
     imageProcessor: ImageProcessor,
     imageUri: Uri? = null,
-    updatePicture: (File) -> Unit
+    updatePicture: (File?) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
@@ -124,7 +124,10 @@ fun CowGroupPhotoPicker(
                         color = MaterialTheme.colorScheme.onPrimary,
                         shape = CircleShape
                     )
-                    .clickable { selectedImageUri = null },
+                    .clickable {
+                        updatePicture(null)
+                        selectedImageUri = null
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 Icon(

--- a/core/designsystem/src/main/java/com/example/designsystem/component/CowGroupPhotoPicker.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/CowGroupPhotoPicker.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -12,9 +13,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -28,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -65,43 +72,66 @@ fun CowGroupPhotoPicker(
                 }
             }
         }
-    Box(
-        modifier = modifier
-            .width(45.dp)
-            .height(55.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.onPrimary,
-                shape = RoundedCornerShape(10.dp)
-            )
-            .clickable {
-                photoPicker.launch(
-                    PickVisualMediaRequest(
-                        ActivityResultContracts.PickVisualMedia.ImageOnly
+    Box(modifier = modifier.padding(end = 12.dp, top = 12.dp)) {
+        Box(
+            modifier = modifier
+                .width(45.dp)
+                .height(55.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    shape = RoundedCornerShape(10.dp)
+                )
+                .clickable {
+                    photoPicker.launch(
+                        PickVisualMediaRequest(
+                            ActivityResultContracts.PickVisualMedia.ImageOnly
+                        )
                     )
+                }, contentAlignment = Alignment.Center
+        ) {
+            if (selectedImageUri != null) {
+                AsyncImage(
+                    model = selectedImageUri,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = "selected_image"
                 )
-            }, contentAlignment = Alignment.Center
-    ) {
+            } else {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        painter = painterResource(R.drawable.baseline_camera_alt_24),
+                        contentDescription = "icon_create_meeting_image"
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "0/1",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
         if (selectedImageUri != null) {
-            AsyncImage(
-                model = selectedImageUri,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop,
-                contentDescription = "selected_image"
-            )
-        } else {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 8.dp, y = (-8).dp)
+                    .size(16.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        shape = CircleShape
+                    )
+                    .clickable { selectedImageUri = null },
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
-                    modifier = Modifier.size(16.dp),
-                    painter = painterResource(R.drawable.baseline_camera_alt_24),
-                    contentDescription = "icon_create_meeting_image"
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "0/1",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onPrimary
+                    imageVector = Icons.Default.Clear,
+                    contentDescription = "remove_image",
+                    tint = Color.White,
+                    modifier = Modifier.size(12.dp)
                 )
             }
         }

--- a/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/theme/Color.kt
@@ -11,7 +11,7 @@ val onPrimaryLight = Color(0xFFB3B3B3)
 val secondaryLight = Color(0xFF02851A)
 val onSecondaryLight = Color(0xFF3D3D3D)
 val tertiaryLight = Color(0xFF006B54)
-val onTertiaryLight = Color(0xFFFFFFFF)
+val onTertiaryLight = Color(0xFFEEEEEE)
 val errorLight = Color(0xFFB3130A)
 val onErrorLight = Color(0xFFFFFFFF)
 

--- a/core/network/src/main/java/com/example/network/retrofit/CowGroupApi.kt
+++ b/core/network/src/main/java/com/example/network/retrofit/CowGroupApi.kt
@@ -70,7 +70,7 @@ interface CowGroupApi {
         @Part("name") name: RequestBody,
         @Part("category") category: RequestBody,
         @Part("capacity") capacity: RequestBody,
-        @Part("content") content: RequestBody): ApiResponse<Unit>
+        @Part("content") content: RequestBody): ApiResponse<Int>
 
     @POST("/events/{event-id}/join")
     suspend fun joinEvent(@Path("event-id") eventId: Int): ApiResponse<Unit>

--- a/feature/home/src/main/java/com/example/home/component/CommentBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/example/home/component/CommentBottomSheetContent.kt
@@ -1,0 +1,109 @@
+package com.example.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.designsystem.theme.CowGroupTheme
+
+@Composable
+fun CommentBottomSheetContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "댓글",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Text(
+                text = "2",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        LazyColumn(
+            modifier = Modifier.height(200.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            items(5) {
+                CommentItem()
+            }
+        }
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(10.dp)),
+                shape = RoundedCornerShape(10.dp),
+                textStyle = MaterialTheme.typography.titleMedium,
+                value = "",
+                onValueChange = {},
+                label = { Text(text = "댓글을 입력해주세요.") },
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.onTertiary,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.onTertiary)
+            )
+
+            Button(
+                onClick = {},
+                shape = RoundedCornerShape(10.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 10.dp),
+                    text = "전송",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CommentBottomSheetContentPreview() {
+    CowGroupTheme {
+        CommentBottomSheetContent()
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/CommentItem.kt
+++ b/feature/home/src/main/java/com/example/home/component/CommentItem.kt
@@ -1,0 +1,65 @@
+package com.example.home.component
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+
+@Composable
+fun CommentItem() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .size(35.dp),
+                model = Uri.parse("https://picsum.photos/200/300"),
+                contentDescription = "profile_img",
+                contentScale = ContentScale.Crop
+            )
+            Text(
+                modifier = Modifier.padding(start = 16.dp),
+                text = "홍길동",
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Text(
+                modifier = Modifier.padding(start = 16.dp),
+                text = "1일 전",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            EditDropDownMenu()
+        }
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text = "반갑습니다.",
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/EditDropDownMenu.kt
+++ b/feature/home/src/main/java/com/example/home/component/EditDropDownMenu.kt
@@ -1,0 +1,39 @@
+package com.example.home.component
+
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+@Composable
+fun EditDropDownMenu() {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = !expanded }) {
+            Icon(Icons.Default.MoreVert, contentDescription = "More options")
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text("수정") },
+                onClick = { Log.d("12", "수정버튼 클릭됨") },
+            )
+            DropdownMenuItem(
+                text = { Text("삭제") },
+                onClick = { }
+            )
+        }
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/EventDetailBoardItem.kt
+++ b/feature/home/src/main/java/com/example/home/component/EventDetailBoardItem.kt
@@ -1,0 +1,131 @@
+package com.example.home.component
+
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.example.designsystem.theme.CowGroupTheme
+import com.example.home.R
+
+@Composable
+fun EventDetailBoardItem(onChatClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .size(35.dp),
+                model = Uri.parse("https://picsum.photos/200/300"),
+                contentDescription = "profile_img",
+                contentScale = ContentScale.Crop
+            )
+
+            Text(
+                modifier = Modifier.padding(start = 8.dp),
+                text = "홍길동",
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Text(
+                modifier = Modifier.padding(start = 12.dp),
+                text = "5월 3일 오전 12:36",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Spacer(modifier = Modifier.weight(1f))
+
+            EditDropDownMenu()
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = "게시글 제목",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text = "게시글 내용",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primaryContainer
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        HorizontalDivider(thickness = 0.5.dp, color = MaterialTheme.colorScheme.onPrimary)
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 30.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable { onChatClick() },
+                painter = painterResource(R.drawable.baseline_chat_bubble_outline_24),
+                contentDescription = "board_item_icon"
+            )
+            Text(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .clickable { onChatClick() },
+                text = "댓글",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primaryContainer
+            )
+            Text(
+                modifier = Modifier.clickable { onChatClick() },
+                text = "2",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EventDetailBoardItemPreview() {
+    CowGroupTheme {
+        EventDetailBoardItem(
+            onChatClick = {}
+        )
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/RegularMeetingBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/example/home/component/RegularMeetingBottomSheetContent.kt
@@ -1,0 +1,208 @@
+package com.example.home.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.designsystem.theme.CowGroupTheme
+import com.example.home.R
+
+@Composable
+fun RegularMeetingBottomSheetContent(onAttendButtonClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            AssistChip(
+                onClick = {},
+                label = { Text(text = "카테고리", style = MaterialTheme.typography.bodySmall) },
+                shape = RoundedCornerShape(6.dp),
+                border = BorderStroke(0.dp, MaterialTheme.colorScheme.onTertiary),
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.onTertiary,
+                    labelColor = MaterialTheme.colorScheme.onPrimary,
+                    leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                ),
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier
+                            .graphicsLayer { scaleX = -1f }
+                            .size(14.dp),
+                        painter = painterResource(R.drawable.baseline_local_offer_24),
+                        contentDescription = "카테고리"
+                    )
+                })
+
+            AssistChip(
+                onClick = {},
+                label = { Text(text = "88명", style = MaterialTheme.typography.bodySmall) },
+                shape = RoundedCornerShape(6.dp),
+                border = BorderStroke(0.dp, MaterialTheme.colorScheme.onTertiary),
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.onTertiary,
+                    labelColor = MaterialTheme.colorScheme.onPrimary,
+                    leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                ),
+                leadingIcon = {
+                    Icon(
+                        modifier = Modifier.size(14.dp),
+                        imageVector = Icons.Default.Person,
+                        contentDescription = "인원"
+                    )
+                })
+        }
+
+        Text(
+            modifier = Modifier.padding(bottom = 10.dp),
+            text = "비 맞으며 뛰는 게 국룰이지\uD83C\uDFC3\u200D♂\uFE0F",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(R.drawable.baseline_calendar_month_24),
+                contentDescription = "icon_meeting_date",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                text = "일시",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                modifier = Modifier.padding(start = 6.dp),
+                text = "4/25 (금) 오후 7:30",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSecondary
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(com.example.navigation.R.drawable.baseline_map_24),
+                contentDescription = "icon_meeting_location",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                text = "위치",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                modifier = Modifier.padding(start = 6.dp),
+                text = "여의도공원",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSecondary
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                imageVector = Icons.Default.Person,
+                contentDescription = "icon_meeting_people",
+                tint = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                text = "참석",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                modifier = Modifier.padding(start = 6.dp),
+                text = buildAnnotatedString {
+                    withStyle(
+                        style = SpanStyle(
+                            color = MaterialTheme.colorScheme.error,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    ) {
+                        append("10")
+                    }
+                    withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onSecondary)) {
+                        append("/20")
+                    }
+                },
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = "(10자리 남음)",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 30.dp),
+            onClick = {},
+            shape = RoundedCornerShape(6.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+        ) {
+            Text(
+                modifier = Modifier.padding(vertical = 10.dp),
+                text = "참석하기",
+                color = Color.White,
+                fontSize = 18.sp
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BottomSheetContentPreview() {
+    CowGroupTheme {
+        RegularMeetingBottomSheetContent(onAttendButtonClick = {})
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/RegularMeetingItem.kt
+++ b/feature/home/src/main/java/com/example/home/component/RegularMeetingItem.kt
@@ -1,0 +1,167 @@
+package com.example.home.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.designsystem.theme.CowGroupTheme
+import com.example.home.R
+
+@Composable
+fun RegularMeetingItem() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.onPrimary,
+                shape = RoundedCornerShape(10.dp)
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 25.dp, horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    modifier = Modifier.padding(bottom = 10.dp),
+                    text = "비 맞으며 뛰는 게 국룰이지\uD83C\uDFC3\u200D♂\uFE0F",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        painter = painterResource(R.drawable.baseline_calendar_month_24),
+                        contentDescription = "icon_meeting_date",
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = "일시",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        modifier = Modifier.padding(start = 6.dp),
+                        text = "4/25 (금) 오후 7:30",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondary
+                    )
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        painter = painterResource(R.drawable.baseline_local_offer_24),
+                        contentDescription = "icon_meeting_location",
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = "위치",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        modifier = Modifier.padding(start = 6.dp),
+                        text = "여의도공원",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondary
+                    )
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        imageVector = Icons.Default.Person,
+                        contentDescription = "icon_meeting_people",
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = "일시",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        modifier = Modifier.padding(start = 6.dp),
+                        text = buildAnnotatedString {
+                            withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                                append("10")
+                            }
+                            withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onSecondary)) {
+                                append("/20")
+                            }
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Text(
+                        text = "(10자리 남음)",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+
+            Button(
+                modifier = Modifier.wrapContentWidth(),
+                onClick = {},
+                shape = RoundedCornerShape(6.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Text(
+                    text = "참석하기",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RegularMeetingItemPreview() {
+    CowGroupTheme {
+        RegularMeetingItem()
+    }
+}

--- a/feature/home/src/main/java/com/example/home/component/RegularMeetingItem.kt
+++ b/feature/home/src/main/java/com/example/home/component/RegularMeetingItem.kt
@@ -1,6 +1,7 @@
 package com.example.home.component
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,7 +34,7 @@ import com.example.designsystem.theme.CowGroupTheme
 import com.example.home.R
 
 @Composable
-fun RegularMeetingItem() {
+fun RegularMeetingItem(onItemClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -43,6 +44,7 @@ fun RegularMeetingItem() {
                 color = MaterialTheme.colorScheme.onPrimary,
                 shape = RoundedCornerShape(10.dp)
             )
+            .clickable { onItemClick() }
     ) {
         Row(
             modifier = Modifier
@@ -90,7 +92,7 @@ fun RegularMeetingItem() {
                 ) {
                     Icon(
                         modifier = Modifier.size(16.dp),
-                        painter = painterResource(R.drawable.baseline_local_offer_24),
+                        painter = painterResource(com.example.navigation.R.drawable.baseline_map_24),
                         contentDescription = "icon_meeting_location",
                         tint = MaterialTheme.colorScheme.onPrimary
                     )
@@ -118,7 +120,7 @@ fun RegularMeetingItem() {
                         tint = MaterialTheme.colorScheme.onPrimary
                     )
                     Text(
-                        text = "일시",
+                        text = "참석",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onPrimary
                     )
@@ -162,6 +164,6 @@ fun RegularMeetingItem() {
 @Composable
 fun RegularMeetingItemPreview() {
     CowGroupTheme {
-        RegularMeetingItem()
+        RegularMeetingItem(onItemClick = {})
     }
 }

--- a/feature/home/src/main/java/com/example/home/presentation/CreateMeetingScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/CreateMeetingScreen.kt
@@ -114,7 +114,7 @@ fun CreateMeetingScreen(
     updateCategory: (String) -> Unit,
     updateCapacity: (String) -> Unit,
     updateContent: (String) -> Unit,
-    choosePhoto: (File) -> Unit,
+    choosePhoto: (File?) -> Unit,
     createMeeting: CreateMeeting,
     isValidCapacity: Boolean,
     capacityMessage: String,

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
@@ -1,9 +1,102 @@
 package com.example.home.presentation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.designsystem.theme.CowGroupTheme
+import com.example.home.R
+import com.example.home.component.BottomSheetContent
+import com.example.home.component.EventDetailBoardItem
 
 @Composable
 fun EventDetailBoardScreen() {
-    Text(text="게시판 화면")
+    val sheetState = rememberModalBottomSheetState()
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = {},
+                icon = {
+                    Icon(
+                        modifier = Modifier.size(18.dp),
+                        painter = painterResource(R.drawable.baseline_create_24),
+                        contentDescription = "Fab_Event_Detail_HomeScreen",
+                        tint = Color.White
+                    )
+                },
+                text = {
+                    Text(
+                        text = "게시글 등록",
+                        fontSize = 18.sp,
+                        color = Color.White
+                    )
+                },
+                containerColor = MaterialTheme.colorScheme.primary
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(5) {
+                    EventDetailBoardItem(onChatClick = {
+                        showBottomSheet = true
+                    })
+                    HorizontalDivider(
+                        thickness = 5.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
+        if (showBottomSheet) {
+            ModalBottomSheet(
+                onDismissRequest = {
+                    showBottomSheet = false
+                },
+                sheetState = sheetState,
+                containerColor = Color.White
+            ) {
+                BottomSheetContent(onAttendButtonClick = {})
+                //val selectedMeeting = meetings.find{ it.id == selectedItemId}
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EventDetailBoardScreenPreview() {
+    CowGroupTheme {
+        EventDetailBoardScreen()
+    }
 }

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
@@ -1,0 +1,9 @@
+package com.example.home.presentation
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun EventDetailBoardScreen() {
+    Text(text="게시판 화면")
+}

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailBoardScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.designsystem.theme.CowGroupTheme
 import com.example.home.R
-import com.example.home.component.BottomSheetContent
+import com.example.home.component.CommentBottomSheetContent
 import com.example.home.component.EventDetailBoardItem
 
 @Composable
@@ -86,7 +86,7 @@ fun EventDetailBoardScreen() {
                 sheetState = sheetState,
                 containerColor = Color.White
             ) {
-                BottomSheetContent(onAttendButtonClick = {})
+                CommentBottomSheetContent()
                 //val selectedMeeting = meetings.find{ it.id == selectedItemId}
             }
         }

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailHomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailHomeScreen.kt
@@ -1,0 +1,215 @@
+package com.example.home.presentation
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.example.designsystem.theme.CowGroupTheme
+import com.example.home.R
+import com.example.home.component.RegularMeetingItem
+
+@Composable
+fun EventDetailHomeScreen(
+    onMemberButtonClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = {},
+                icon = {
+                    Icon(
+                        modifier = Modifier.size(18.dp),
+                        painter = painterResource(R.drawable.baseline_create_24),
+                        contentDescription = "Fab_Event_Detail_HomeScreen",
+                        tint = Color.White
+                    )
+                },
+                text = {
+                    Text(
+                        text = "정기모임 등록",
+                        fontSize = 18.sp,
+                        color = Color.White
+                    )
+                },
+                containerColor = MaterialTheme.colorScheme.primary
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(scrollState)
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                model = "https://picsum.photos/200/300",
+                contentDescription = ""
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AssistChip(
+                    onClick = {},
+                    label = { Text(text = "카테고리", style = MaterialTheme.typography.bodySmall) },
+                    shape = RoundedCornerShape(6.dp),
+                    border = BorderStroke(0.dp, MaterialTheme.colorScheme.onTertiary),
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.onTertiary,
+                        labelColor = MaterialTheme.colorScheme.onPrimary,
+                        leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                    ),
+                    leadingIcon = {
+                        Icon(
+                            modifier = Modifier
+                                .graphicsLayer { scaleX = -1f }
+                                .size(14.dp),
+                            painter = painterResource(R.drawable.baseline_local_offer_24),
+                            contentDescription = "카테고리"
+                        )
+                    })
+
+                AssistChip(
+                    onClick = onMemberButtonClick,
+                    label = { Text(text = "88명", style = MaterialTheme.typography.bodySmall) },
+                    shape = RoundedCornerShape(6.dp),
+                    border = BorderStroke(0.dp, MaterialTheme.colorScheme.onTertiary),
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.onTertiary,
+                        labelColor = MaterialTheme.colorScheme.onPrimary,
+                        leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                    ),
+                    leadingIcon = {
+                        Icon(
+                            modifier = Modifier.size(14.dp),
+                            imageVector = Icons.Default.Person,
+                            contentDescription = "인원"
+                        )
+                    })
+            }
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                text = "여의도 한강공원 러닝크루",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                text = "\uD83C\uDFC3\u200D♂\uFE0F 여의도 한강공원 러닝크루\n 주말마다 함께 달리는 러닝크루입니다. 초보자부터 경험자까지 모두 환영!\n" +
+                        "\n" +
+                        "\uD83C\uDF33 건강 & 운동\n 한강의 자연을 느끼며, 함께 달리며 건강을 챙겨요.\n" +
+                        "\n" +
+                        "\uD83D\uDC65 친목 & 소통\n 새로운 사람들과 친목을 나누고, 운동 후 대화의 시간도 가져요.\n" +
+                        "\n" +
+                        "\uD83C\uDFC5 초보자 환영\n 운동에 익숙하지 않더라도 천천히 따라올 수 있는 일정으로 구성됩니다.\n" +
+                        "\n" +
+                        "\uD83D\uDDD3 주말 모임\n 매주 주말, 여의도 한강공원에서 만나요!\n" +
+                        "\n" +
+                        "\uD83D\uDCAC 편안한 분위기\n 스트레칭과 간단한 대화로 서로를 더 잘 알 수 있는 시간을 마련합니다.",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSecondary
+            )
+            Spacer(modifier = Modifier.height(30.dp))
+            HorizontalDivider(thickness = 4.dp, color = MaterialTheme.colorScheme.onTertiary)
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                text = "정기모임",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn(
+                modifier = Modifier
+                    .height(400.dp)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(5) {
+                    RegularMeetingItem()
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = {},
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 30.dp),
+                shape = RoundedCornerShape(10.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                enabled = true,
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 10.dp),
+                    text = "가입하기",
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 18.sp,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EventDetailHomeScreenPreview() {
+    CowGroupTheme {
+        EventDetailHomeScreen(
+            onMemberButtonClick = {}
+        )
+    }
+}

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailHomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailHomeScreen.kt
@@ -24,9 +24,15 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -38,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.example.designsystem.theme.CowGroupTheme
 import com.example.home.R
+import com.example.home.component.RegularMeetingBottomSheetContent
 import com.example.home.component.RegularMeetingItem
 
 @Composable
@@ -45,6 +52,8 @@ fun EventDetailHomeScreen(
     onMemberButtonClick: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    val sheetState = rememberModalBottomSheetState()
+    var showBottomSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -177,7 +186,9 @@ fun EventDetailHomeScreen(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 items(5) {
-                    RegularMeetingItem()
+                    RegularMeetingItem(onItemClick = {
+                        showBottomSheet = true
+                    })
                 }
             }
 
@@ -199,6 +210,18 @@ fun EventDetailHomeScreen(
                     fontSize = 18.sp,
                     color = Color.White
                 )
+            }
+        }
+        if (showBottomSheet) {
+            ModalBottomSheet(
+                onDismissRequest = {
+                    showBottomSheet = false
+                },
+                sheetState = sheetState,
+                containerColor = Color.White
+            ) {
+                RegularMeetingBottomSheetContent(onAttendButtonClick = {})
+                //val selectedMeeting = meetings.find{ it.id == selectedItemId}
             }
         }
     }

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailScreen.kt
@@ -50,6 +50,7 @@ import com.example.designsystem.component.CowGroupDialog
 import com.example.designsystem.component.MarkButton
 import com.example.designsystem.theme.CowGroupTheme
 import com.example.home.R
+import com.example.home.component.EditDropDownMenu
 import com.example.home.viewmodel.EventDetailUIState
 import com.example.home.viewmodel.EventDetailViewModel
 import com.example.model.DetailEvent
@@ -143,7 +144,7 @@ fun EventDetailScreen(
                     }
                 },
                 actions = {
-                    Row {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         if (detailEvent.editRights) {
                             IconButton(onClick = onEditButtonClick) {
                                 Icon(
@@ -170,6 +171,7 @@ fun EventDetailScreen(
                                 contentDescription = "공유하기"
                             )
                         }
+                        EditDropDownMenu()
                     }
                 }
             )

--- a/feature/home/src/main/java/com/example/home/presentation/EventDetailScreen.kt
+++ b/feature/home/src/main/java/com/example/home/presentation/EventDetailScreen.kt
@@ -14,22 +14,26 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -44,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.designsystem.component.CowGroupDialog
 import com.example.designsystem.component.MarkButton
+import com.example.designsystem.theme.CowGroupTheme
 import com.example.home.R
 import com.example.home.viewmodel.EventDetailUIState
 import com.example.home.viewmodel.EventDetailViewModel
@@ -116,14 +121,17 @@ fun EventDetailScreen(
     onConfirmDialog: () -> Unit,
     snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
+    var state by remember { mutableIntStateOf(0) }
+    val titles = listOf("홈", "게시판")
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            CenterAlignedTopAppBar(
+            TopAppBar(
                 title = {
                     Text(
-                        text = "모임 상세",
-                        style = MaterialTheme.typography.titleMedium
+                        text = "모임 채널",
+                        style = MaterialTheme.typography.titleLarge
                     )
                 },
                 navigationIcon = {
@@ -156,6 +164,12 @@ fun EventDetailScreen(
                             markedIconId = R.drawable.baseline_bookmarks_24,
                             unMarkedIconId = R.drawable.baseline_bookmarks_24,
                         )
+                        IconButton(onClick = {}) {
+                            Icon(
+                                imageVector = Icons.Default.Share,
+                                contentDescription = "공유하기"
+                            )
+                        }
                     }
                 }
             )
@@ -184,9 +198,20 @@ fun EventDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .padding(top = 8.dp, bottom = 8.dp)
         ) {
+            SecondaryTabRow(selectedTabIndex = state) {
+                titles.forEachIndexed { index, title ->
+                    Tab(
+                        text = { Text(text = title) },
+                        selected = state == index,
+                        onClick = { state = index })
+                }
+            }
+            when (state) {
+                0 -> EventDetailHomeScreen { onMemberButtonClick(detailEvent.id) }
+                1 -> EventDetailBoardScreen()
+            }
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = MaterialTheme.shapes.large,
@@ -319,30 +344,32 @@ fun EventDetailScreen(
 @Preview(showBackground = true)
 @Composable
 fun EventDetailPreview() {
-    EventDetailScreen(
-        onMemberButtonClick = {},
-        onJoinButtonClick = {},
-        onNavigationButtonClick = {},
-        onBookmarkButtonClick = {},
-        onDeleteButtonClick = {},
-        onEditButtonClick = {},
-        detailEvent = DetailEvent(
-            id = 0,
-            name = "test",
-            author = "android",
-            category = "Sports",
-            createdDate = "2025-10-25",
-            location = "장소",
-            content = "내용",
-            eventDate = "2025-10-28",
-            capacity = 100,
-            applicants = 20,
-            isBookmarked = false,
-            editRights = false,
-            isParticipated = false
-        ),
-        showDialog = false,
-        onDismissDialog = {},
-        onConfirmDialog = {}
-    )
+    CowGroupTheme {
+        EventDetailScreen(
+            onMemberButtonClick = {},
+            onJoinButtonClick = {},
+            onNavigationButtonClick = {},
+            onBookmarkButtonClick = {},
+            onDeleteButtonClick = {},
+            onEditButtonClick = {},
+            detailEvent = DetailEvent(
+                id = 0,
+                name = "test",
+                author = "android",
+                category = "Sports",
+                createdDate = "2025-10-25",
+                location = "장소",
+                content = "내용",
+                eventDate = "2025-10-28",
+                capacity = 100,
+                applicants = 20,
+                isBookmarked = false,
+                editRights = false,
+                isParticipated = false
+            ),
+            showDialog = false,
+            onDismissDialog = {},
+            onConfirmDialog = {}
+        )
+    }
 }

--- a/feature/home/src/main/java/com/example/home/viewmodel/CreateMeetingViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/viewmodel/CreateMeetingViewModel.kt
@@ -66,12 +66,12 @@ class CreateMeetingViewModel @Inject constructor(
         viewModelScope.launch {
             _createMeetingUIState.update { state -> state.copy(isLoading = true, message = "") }
             try {
-                eventRepository.createMeeting(createMeetingUIState.value.createMeeting) // 서버에서 eventId 받아서 state 수정해야함
+                val result = eventRepository.createMeeting(createMeetingUIState.value.createMeeting)
                 _createMeetingUIState.update { state ->
                     state.copy(
                         isCreateMeetingSuccess = true,
                         isLoading = false,
-                        eventId = 12, // 서버에서 eventId 전달시 수정
+                        eventId = result,
                         message = "모임 생성이 완료되었습니다.",
                     )
                 }

--- a/feature/home/src/main/java/com/example/home/viewmodel/CreateMeetingViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/viewmodel/CreateMeetingViewModel.kt
@@ -127,7 +127,7 @@ class CreateMeetingViewModel @Inject constructor(
         }
     }
 
-    fun updateFile(file: File) {
+    fun updateFile(file: File?) {
         _createMeetingUIState.update { state ->
             val createMeeting = state.createMeeting.copy(file = file)
             state.copy(createMeeting = createMeeting)

--- a/feature/home/src/main/res/drawable/baseline_calendar_month_24.xml
+++ b/feature/home/src/main/res/drawable/baseline_calendar_month_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6C21,4.9 20.1,4 19,4zM19,20H5V10h14V20zM9,14H7v-2h2V14zM13,14h-2v-2h2V14zM17,14h-2v-2h2V14zM9,18H7v-2h2V18zM13,18h-2v-2h2V18zM17,18h-2v-2h2V18z"/>
+    
+</vector>

--- a/feature/home/src/main/res/drawable/baseline_chat_bubble_outline_24.xml
+++ b/feature/home/src/main/res/drawable/baseline_chat_bubble_outline_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,2L4,2c-1.1,0 -2,0.9 -2,2v18l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,16L6,16l-2,2L4,4h16v12z"/>
+    
+</vector>

--- a/feature/home/src/main/res/drawable/baseline_create_24.xml
+++ b/feature/home/src/main/res/drawable/baseline_create_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+    
+</vector>


### PR DESCRIPTION
👩‍🌾 진행한 작업

- EventDetailScreen UI 수정
☑ SecondaryTabRow 구현
☑ 편집, 삭제 DropDownMenu 구현

- EventDetailHomeScreen UI 구현
☑정기모임 LazyColumn 구현
☑ 정기모임 BottomSheet UI 구현

- EventDetailBoardScreen UI 구현
☑ CommentItem UI 구현
☑ CommentBottomSheet UI 구현

- CowGroupPhotopicker 이미지 초기화 기능 구현

📷 작업 결과

https://github.com/user-attachments/assets/d0242056-58e9-420a-8532-f1660d4b26ba

closed #50 